### PR TITLE
Bug fix reading of the puppet lock file

### DIFF
--- a/bin/puppet-stopper
+++ b/bin/puppet-stopper
@@ -100,8 +100,7 @@ class AgentLocker
   end
 
   def lock_file
-    return @lock_file if @lock_file
-    @lock_file = File.join(state_dir, LOCKFILE_BASE)
+    @lock_file ||= File.join(state_dir, LOCKFILE_BASE)
   end
 
   private
@@ -111,8 +110,7 @@ class AgentLocker
     return @state_dir if @state_dir
     STATE_DIR.each do |state_dir|
       next unless File.exist?(state_dir)
-      @state_dir = state_dir
-      break
+      return @state_dir = state_dir
     end
   end
 end


### PR DESCRIPTION
The AgentLocker.state_dir method didn't return a proper  value and prevented reading the puppet agent's lock file. This fixes the return value of and also removes a line of bloat from AgentLocker.lock_file.